### PR TITLE
split multiline string into vector of one-liners

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -529,7 +529,14 @@ function execute_notebook(nb)
             execute_result["output_type"] = "execute_result"
             execute_result["metadata"] = Dict()
             execute_result["execution_count"] = execution_count
-            execute_result["data"] = IJulia.display_dict(r)
+            dd = IJulia.display_dict(r)
+            # we need to split some mime types into vectors of lines instead of a single string
+            for mime in ("image/svg+xml", "text/html")
+                if haskey(dd, mime)
+                    dd[mime] = collect(Any, eachline(IOBuffer(dd[mime]), chomp = false))
+                end
+            end
+            execute_result["data"] = dd
 
             push!(cell["outputs"], execute_result)
         end


### PR DESCRIPTION
this is needed for image/svg+xml and text/html

This fixes the Literate.jl part of #8.