### PR TITLE
RFC: Add support for Jupyter cell metadata via %% syntax

### DIFF
--- a/docs/src/outputformats.md
+++ b/docs/src/outputformats.md
@@ -51,6 +51,22 @@ arguments to [`Literate.notebook`](@ref):
 Literate.notebook
 ```
 
+### Notebook metadata
+
+Jupyter notebook cells (both code cells and markdown cells) can contain metadata. This is enabled
+in Literate by the `%%` token, similar to
+[Jupytext](https://jupytext.readthedocs.io/en/latest/formats.html#the-percent-format).
+The format is as follows
+
+```
+%% optional ignored text [type] {optional metadata JSON}
+```
+
+Cell metadata can, for example, be used for
+[nbgrader](https://nbgrader.readthedocs.io/en/stable/contributor_guide/metadata.html)
+and the [reveal.js](https://github.com/hakimel/reveal.js) notebook extension
+[RISE](https://github.com/damianavila/RISE).
+
 
 ## [**4.3.** Script Output](@id Script-Output)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,18 @@ content = """
     #+
         ## Indented comment
     end
+
+    #nb # A notebook cell with special metadata
+    #nb %% Meta1 {"meta": "data"}
+    #nb 1+1
+    #nb #-
+    #nb # A explicit code notebook cell
+    #nb #-
+    #nb %% [code]
+    #nb 1+2
+    #nb #-
+    #nb # %% [markdown] {"meta": "data"}
+    #nb # # Explicit markdown cell with metadata
     """
 
 @testset "Literate.script" begin
@@ -585,6 +597,12 @@ end
             """,
 
             """
+               "metadata": {
+                "meta": "data"
+               }
+            """,
+
+            """
                "source": [
                 "*This notebook was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*"
                ]
@@ -691,6 +709,7 @@ end
             r = try
                 Literate.notebook(inputfile, outdir)
             catch err
+                @info "^^ the above error log message is expected ^^"
                 err
             end
             @test isa(r, ErrorException)


### PR DESCRIPTION
Admittedly this is a little strange: it adds support for a special first-line syntax that only applies to Jupyter notebook outputs. But this %% format is somewhat standard across notebook-generating tools, and the ability to protect it with a `#nb` leader makes it possible to specifically target this line to a notebook output. We aim to use something like this for generation of notebooks with support for nbgrader's metadata extensions, but it could also be used to specify cell types for Jupyter notebook presentations \(with presentation extensions\) or other such fun.

See https://github.com/mwouts/jupytext/blob/master/README.md#the-percent-format for more details about this format.