### PR TITLE
Import JSON inside IJulia submodule

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -1,6 +1,7 @@
 # this file contains some utilities copied from the IJulia.jl package
 # (https://github.com/JuliaLang/IJulia.jl), see LICENSE.md for license
 module IJulia
+import JSON
 using Base64
 
 const text_plain = MIME("text/plain")


### PR DESCRIPTION
This is required for using VegaLite.jl inside the notebook.