### PR TITLE
Call IJulia.display_dict with invokelatest to fix VegaLite issue

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -56,16 +56,14 @@ function limitstringmime(mime::MIME, x)
         if israwtext(mime, x)
             return String(x)
         else
-            # show(IOContext(buf, :limit=>true, :color=>true), mime, x)
-            Base.invokelatest(show, IOContext(buf, :limit=>true, :color=>true), mime, x)
+            show(IOContext(buf, :limit=>true, :color=>true), mime, x)
         end
     else
         b64 = Base64EncodePipe(buf)
         if isa(x, Vector{UInt8})
             write(b64, x) # x assumed to be raw binary data
         else
-            # show(IOContext(b64, :limit=>true, :color=>true), mime, x)
-            Base.invokelatest(show, IOContext(b64, :limit=>true, :color=>true), mime, x)
+            show(IOContext(b64, :limit=>true, :color=>true), mime, x)
         end
         close(b64)
     end

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -561,7 +561,7 @@ function execute_notebook(nb)
             execute_result["output_type"] = "execute_result"
             execute_result["metadata"] = Dict()
             execute_result["execution_count"] = execution_count
-            dd = IJulia.display_dict(r)
+            dd = Base.invokelatest(IJulia.display_dict, r)
             # we need to split some mime types into vectors of lines instead of a single string
             for mime in ("image/svg+xml", "text/html")
                 if haskey(dd, mime)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -647,6 +647,20 @@ end
 
             # verify that inputfile exists
             @test_throws ArgumentError Literate.notebook("nonexistent.jl", outdir)
+
+            # world time problem with `IJulia.display_dict`
+            write(inputfile, """
+            struct VegaLiteRenderable end
+            Base.show(io::IO, ::MIME"application/vnd.vegalite.v2+json", ::VegaLiteRenderable) =
+                write(io, \"\"\"
+            {"encoding":{"x":{"field":"x","type":"quantitative"},"y":{"field":"y","type":"quantitative"}},"data":{"values":[{"x":1,"y":1},{"x":2,"y":3},{"x":3,"y":2}]},"mark":"point"}
+            \"\"\")
+            Base.Multimedia.istextmime(::MIME{Symbol("application/vnd.vegalite.v2+json")}) = true
+            VegaLiteRenderable()
+            """)
+            Literate.notebook(inputfile, outdir)
+            notebook = read(joinpath(outdir, "inputfile.ipynb"), String)
+            @test occursin("\"application/vnd.vegalite.v2+json\":", notebook)
         end
     end
 end


### PR DESCRIPTION
Before this PR, calling `Literate.notebook` containing plots using `VegaLite` for the first time _before_ importing `VegaLite` resulted in a JSON parse error.  You can check it via:

```
$ julia --startup-file=no --banner=no
shell> cat bug_vegalite.jl
using VegaLite
[(x=1, y=2)] |> @vlplot(:point, x=:x, y=:y)

julia> using Literate

julia> Literate.notebook("bug_vegalite.jl", ".")
```

or

```
git clone https://gist.github.com/1962dd4f17eec165b4fbe3f113711c68 bug
cd bug
make
```

which should print something like

```
julia --color=yes --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate()'
  Updating registry at `~/.julia/registries/General`
  Updating git-repo `https://github.com/JuliaRegistries/General.git`
julia --color=yes --startup-file=no --project=. \
-e 'using Literate; Literate.notebook("bug_vegalite.jl", ".")'
[ Info: generating notebook from `.../bug/bug_vegalite.jl`
[ Info: not running on Travis, skipping links will not be correct.
[ Info: executing notebook `bug_vegalite.ipynb`
┌ Error: error when executing notebook based on input file: `.../bug/bug_vegalite.jl`
└ @ Literate ~/.julia/packages/Literate/knnP2/src/Literate.jl:495
ERROR: Unexpected character
Line: 0
Around: ...eyJlbmNvZGluZyI6eyJ4Ij...
            ^
```

The problem was that VegaLite.jl [defines `istextmime(::MIME{Symbol("application/vnd.vegalite.v2+json")}) = true`](https://github.com/fredo-dedup/VegaLite.jl/blob/60aa6b46da62968055c817277f762e8eee0bbcb8/src/rendering/show.jl#L44) while `Literate.IJulia.limitstringmime` calls `istextmime` without `invokelatest`:

https://github.com/fredrikekre/Literate.jl/blob/82e7af756c574a84ffbce61cc2e0ecea24fc46c5/src/IJulia.jl#L53-L55

while using `invokelatest` for `show`

https://github.com/fredrikekre/Literate.jl/blob/82e7af756c574a84ffbce61cc2e0ecea24fc46c5/src/IJulia.jl#L68

So, `application/vnd.vegalite.v2+json` was miss-classified as non-text MIME and got encoded using base64.  Then JSON parser complained because it was expecting a raw string of JSON:

https://github.com/fredrikekre/Literate.jl/blob/82e7af756c574a84ffbce61cc2e0ecea24fc46c5/src/IJulia.jl#L21-L22

This can be fixed by simply calling `display_dict` with `invokelatest` so that we can use the latest `istextmime` which may be defined inside user's code.  I think this is the right way to do it, as we can use the latest and consistent display-related methods this way.  Note that [IJulia calls `display_dict` with `invokelatest`](https://github.com/JuliaLang/IJulia.jl/blob/1d7dc506d676ad56b9fc581e1f2c723c9b2a5f4a/src/execute_request.jl#L97).
