### PR TITLE
Change the folder from "latest" to "dev"

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -171,7 +171,7 @@ function replace_default(content, sym;
     ## use same logic as Documenter to figure out the deploy folder
     travis_tag = get(ENV, "TRAVIS_TAG", "TRAVIS_TAG")
     if isempty(travis_tag)
-        folder = "latest"
+        folder = "dev"
     else
         # use the versioned directory for links, even for the stable and release-
         # folders since this will never change

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -250,7 +250,7 @@ content = """
                 Literate.script(inputfile, outdir)
             end
             script = read(joinpath(outdir, "inputfile.jl"), String)
-            @test occursin("fredrikekre/Literate.jl/blob/gh-pages/latest/", script)
+            @test occursin("fredrikekre/Literate.jl/blob/gh-pages/dev/", script)
 
             # pre- and post-processing
             Literate.script(inputfile, outdir,
@@ -378,7 +378,7 @@ end
                 Literate.markdown(inputfile, outdir)
             end
             markdown = read(joinpath(outdir, "inputfile.md"), String)
-            @test occursin("fredrikekre/Literate.jl/blob/gh-pages/latest/", markdown)
+            @test occursin("fredrikekre/Literate.jl/blob/gh-pages/dev/", markdown)
 
             # pre- and post-processing
             Literate.markdown(inputfile, outdir,
@@ -562,7 +562,7 @@ end
                 Literate.notebook(inputfile, outdir, execute = false)
             end
             notebook = read(joinpath(outdir, "inputfile.ipynb"), String)
-            @test occursin("fredrikekre/Literate.jl/blob/gh-pages/latest/", notebook)
+            @test occursin("fredrikekre/Literate.jl/blob/gh-pages/dev/", notebook)
 
             # pre- and post-processing
             function post(nb)


### PR DESCRIPTION
This changes the folder variable to "dev" instead of "latest" when `travis_tag` is empty,
Documenter uses "dev" now instead of "latest", whilst latest is currently symlinked by
Documenter to provide some backward compatibility, it still breaks some things like using `@__NBVIEWER_ROOT_URL__`