### PR TITLE
Strike-through dead link

### DIFF
--- a/docs/src/customprocessing.md
+++ b/docs/src/customprocessing.md
@@ -95,7 +95,9 @@ Literate.markdown("examples.jl", "path/to/save/markdown";
 and you will see that in the final output file (here `markdown_file_name.md`) the `include`
 statements are replaced with the actual code to be included!
 
-This approach is used for example in the documentation of the Julia package
-[`TimeseriesPrediction`](https://github.com/JuliaDynamics/TimeseriesPrediction.jl),
-see [~here~](https://github.com/JuliaDynamics/DynamicalSystems.jl/blob/master/docs/src/tsprediction/stexamples.jl)
-and [here for the generating script](https://github.com/JuliaDynamics/DynamicalSystems.jl/blob/master/docs/make.jl#L11-L29)
+This approach is used for generating [the examples](https://juliadynamics.github.io/TimeseriesPrediction.jl/latest/stexamples/)
+in the documentation of the [TimeseriesPrediction.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl) package.
+The [example files](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/tree/master/examples),
+included together in the [stexamples.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/blob/master/docs/src/stexamples.jl) file,
+are processed by literate via this [make.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/blob/master/docs/make.jl) file to generate the markdown and code cells of the documentation.
+

--- a/docs/src/customprocessing.md
+++ b/docs/src/customprocessing.md
@@ -97,7 +97,15 @@ statements are replaced with the actual code to be included!
 
 This approach is used for generating [the examples](https://juliadynamics.github.io/TimeseriesPrediction.jl/latest/stexamples/)
 in the documentation of the [TimeseriesPrediction.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl) package.
-The [example files](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/tree/master/examples),
-included together in the [stexamples.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/blob/master/docs/src/stexamples.jl) file,
-are processed by literate via this [make.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/blob/master/docs/make.jl) file to generate the markdown and code cells of the documentation.
+The 
+[example files](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/tree/dcb080376a7861716147c04e45c473f55bb9a078/examples),
+included together in the 
+[stexamples.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/blob/dcb080376a7861716147c04e45c473f55bb9a078/docs/src/stexamples.jl) file,
+are processed by literate via this
+[make.jl](https://github.com/JuliaDynamics/TimeseriesPrediction.jl/blob/dcb080376a7861716147c04e45c473f55bb9a078/docs/make.jl) 
+file to generate the markdown and code cells of the documentation.
+
+
+
+
 

--- a/docs/src/customprocessing.md
+++ b/docs/src/customprocessing.md
@@ -95,4 +95,7 @@ Literate.markdown("examples.jl", "path/to/save/markdown";
 and you will see that in the final output file (here `markdown_file_name.md`) the `include`
 statements are replaced with the actual code to be included!
 
-This approach is used for example in the documentation of the Julia package [`TimeseriesPrediction`](https://github.com/JuliaDynamics/TimeseriesPrediction.jl), see [here](https://github.com/JuliaDynamics/DynamicalSystems.jl/blob/master/docs/src/tsprediction/stexamples.jl) and [here for the generating script](https://github.com/JuliaDynamics/DynamicalSystems.jl/blob/master/docs/make.jl#L11-L29)
+This approach is used for example in the documentation of the Julia package
+[`TimeseriesPrediction`](https://github.com/JuliaDynamics/TimeseriesPrediction.jl),
+see [~here~](https://github.com/JuliaDynamics/DynamicalSystems.jl/blob/master/docs/src/tsprediction/stexamples.jl)
+and [here for the generating script](https://github.com/JuliaDynamics/DynamicalSystems.jl/blob/master/docs/make.jl#L11-L29)


### PR DESCRIPTION
The link that is struck through is dead.

I was reading the documentation before trying to use Literate.jl and saw this dead link. I'm not sure how to replace it so I just struck it out and submitted this PR, hoping to make it easy for you to spot and edit yourself if you want! 🙂 