### PR TITLE
Fix ignored continued=false in parse()

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -78,17 +78,19 @@ function parse(content; allow_continued = true)
         end
     end
 
-    # find code chunks that are continued
-    last_code_chunk = 0
-    for (i, chunk) in enumerate(chunks)
-        isa(chunk, MDChunk) && continue
-        if startswith(last(chunk.lines)," ")
-            chunk.continued = true
+    if allow_continued
+        # find code chunks that are continued
+        last_code_chunk = 0
+        for (i, chunk) in enumerate(chunks)
+            isa(chunk, MDChunk) && continue
+            if startswith(last(chunk.lines)," ")
+                chunk.continued = true
+            end
+            if startswith(first(chunk.lines)," ")
+                chunks[last_code_chunk].continued = true
+            end
+            last_code_chunk = i
         end
-        if startswith(first(chunk.lines)," ")
-            chunks[last_code_chunk].continued = true
-        end
-        last_code_chunk = i
     end
 
     # if we don't allow continued code blocks we need to merge MDChunks into the CodeChunks


### PR DESCRIPTION
This fixes a situation where the continued=false option in parse() was
ignored during notebook export.

The code can further be cleaned up by combining the block changed with the next block in an if-else-end block.  However, I went with the most minimal change here.

This partially addresses #41.