### PR TITLE
Use $$...$$ instead of equation environment

### DIFF
--- a/docs/src/documenter.md
+++ b/docs/src/documenter.md
@@ -41,9 +41,9 @@ if we set `documenter = true`:
   ````
   is replaced with notebook compatible
   ```
-  \begin{equation}
+  $$
   \int f dx
-  \end{equation}
+  $$
   ```
 
 ### [`Literate.script`](@ref):

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -157,7 +157,7 @@ function replace_default(content, sym;
         push!(repls, r"^#!nb.*\n?"m => "") # remove #!nb lines
         push!(repls, r"^#jl.*\n?"m => "")  # remove leading #jl lines
         push!(repls, r"^#!jl "m => "")     # remove leading #!jl
-        push!(repls, r"```math(.*?)```"s => s"\\begin{equation}\1\\end{equation}")
+        push!(repls, r"```math(.*?)```"s => s"$$\1$$")
     else # sym === :jl
         push!(repls, r"^#md.*\n?"m => "")  # remove #md lines
         push!(repls, r"^#!md "m => "")     # remove leading #!md

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -611,9 +611,9 @@ end
             """
                "source": [
                 "Some math:\\n",
-                "\\\\begin{equation}\\n",
+                "\$\$\\n",
                 "\\\\int f(x) dx\\n",
-                "\\\\end{equation}"
+                "\$\$"
                ]
             """,
 


### PR DESCRIPTION
I noticed that MathJax does not display
```tex
\begin{equation}
\begin{align}
a &= 0 \\
b &= 1
\end{align}
\end{equation}
```
correctly but works if
```tex
$$
\begin{align}
a &= 0 \\
b &= 1
\end{align}
$$
```
is used. This behaviour can be reproduced in the [online demo of MathJax](https://www.mathjax.org/#demo).

For my (more complicated) use case I could fix this issue by using the preproccessing method
```julia
replace_math(content) = replace(content, r"```math(.*?)```"s => s"$$\1$$")
```
in the Jupyter notebook exports. However, apparently people ran into [similar issues with Weave.jl](https://github.com/JunoLab/Weave.jl/issues/182), and hence maybe it would be better to generally replace ` ```math...``` ` with `$$...$$` instead of `\begin{equation}...\end{equation}` in Jupyter notebooks.