### PR TITLE
Fix notebook validation warning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Literate"
 uuid = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
-version = "2.3.0"
+version = "2.3.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -514,9 +514,9 @@ function notebook(inputfile, outputdir; config::Dict=Dict(), kwargs...)
         cell["cell_type"] = chunktype
         cell["metadata"] = metadata
         cell["source"] = lines
-        cell["outputs"] = []
         if chunktype == "code"
             cell["execution_count"] = nothing
+            cell["outputs"] = []
         end
         push!(cells, cell)
     end


### PR DESCRIPTION
Previously, Jupyter complained about an unexpected property for markdown
cells. So it is added for code cells only now.

![Bildschirmfoto 2020-03-21 um 19 17 09](https://user-images.githubusercontent.com/8181318/77233783-08888b00-6baa-11ea-889f-85623976dd0e.png)
