### PR TITLE
fixed minor typo

### DIFF
--- a/docs/src/tips.md
+++ b/docs/src/tips.md
@@ -37,5 +37,5 @@ HTML formats.
     be showable as just `image/png` and `text/plain` you can use
     ```julia
     img = plot(...)
-    img = DisplayAs.Text(DisplayAs.Text(img))
+    img = DisplayAs.Text(DisplayAs.PNG(img))
     ```


### PR DESCRIPTION
replaced `img = DisplayAs.Text(DisplayAs.Text(img))` with `img = DisplayAs.Text(DisplayAs.PNG(img))` since we require it to be showable as both `text/plain` and `image/png`