### PR TITLE
[CI] pass julia-arch ENV to setup-julia stage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,13 +14,14 @@ jobs:
     strategy:
       matrix:
         julia-version: [1.4]
-        julia-arch: [x86]
+        julia-arch: [x64]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1.0.0
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
       - name: Install dependencies
         run: julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy


### PR DESCRIPTION
Also change it to x64 to match the current build settings.

Co-authored-by: kimikage <kimikage.ceo@gmail.com>