### PR TITLE
link to the repo in the docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,8 @@
 # [**1.** Introduction](@id Introduction)
 
-Welcome to the documentation for Literate -- a simplistic package
-for [Literate Programming](https://en.wikipedia.org/wiki/Literate_programming).
+Welcome to the documentation for [Literate](https://github.com/fredrikekre/Literate.jl) 
+-- a simplistic package for
+[Literate Programming](https://en.wikipedia.org/wiki/Literate_programming).
 
 ### What?
 


### PR DESCRIPTION
This makes is easier for people to get to the source code of Literate.jl if they find the documentation, e.g. using Google.