### PR TITLE
fixed offline default

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -186,9 +186,9 @@ function replace_default(content, sym;
         nbviewer_root_url = "https://nbviewer.jupyter.org/urls/$(base_url)"
         push!(repls, "@__NBVIEWER_ROOT_URL__" => nbviewer_root_url)
     else
-        push!(repls, "@__REPO_ROOT_URL__" => get(config, "repo_root_url", "<unknown>"))
-        push!(repls, "@__NBVIEWER_ROOT_URL__" => get(config, "nbviewer_root_url", "<unknown>"))
-        push!(repls, "@__BINDER_ROOT_URL__" => get(config, "binder_root_url", "<unknown>"))
+        push!(repls, "@__REPO_ROOT_URL__" => get(config, "repo_root_url", pwd()))
+        push!(repls, "@__NBVIEWER_ROOT_URL__" => get(config, "nbviewer_root_url", pwd()))
+        push!(repls, "@__BINDER_ROOT_URL__" => get(config, "binder_root_url", pwd()))
     end
 
     # run some Documenter specific things


### PR DESCRIPTION
Fixed the offline default to provide a cogent path for the meta link at the top of markdown output files