### PR TITLE
Proposal: Alternate Julia comment syntax

### DIFF
--- a/docs/src/fileformat.md
+++ b/docs/src/fileformat.md
@@ -14,6 +14,8 @@ The basic syntax is simple:
 Leading whitespace is allowed before `#`, but it will be removed when generating the
 output. Since `#`-lines are treated as markdown we can not use that for regular julia
 comments, for this you can instead use `## `, which will render as `# ` in the output.
+Alternatively, you can use `#~` for regular julia comments, which will render as `#` 
+and behaves well with code cell delimiters in VSCode.
 
 Lets look at a simple example:
 ```julia

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -77,6 +77,8 @@ function parse(content; allow_continued = true)
             end
             # remove "## " and "##\n"
             line = replace(replace(line, r"^(\h*)#(# .*)$" => s"\1\2"), r"^(\h*#)#$" => s"\1")
+            # similarly, change "#~x" to "#x" and remove "#~\n"
+            line = replace(replace(line, r"^(\h*)#~(.*)$" => s"\1#\2"), r"^(\h*#)~$" => s"\1")
             push!(chunks[end].lines, line)
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,14 @@ end
         ## Line 77
         ##
         ## Line 79
+    #-
+    #~ Line 81
+    #~
+    #~ Line 83
+    #-
+        #~ Line 85
+        #~
+        #~ Line 87
     """
     expected_chunks = Chunk[
         MDChunk(["" => "Line 1"]),
@@ -145,6 +153,8 @@ end
         CodeChunk(["Line 64", "    # Line 65", "    Line 66", "Line 67"], false),
         CodeChunk(["# Line 73", "#", "# Line 75"], false),
         CodeChunk(["    # Line 77", "    #", "    # Line 79"], false),
+        CodeChunk(["# Line 81", "#", "# Line 83"], false),
+        CodeChunk(["    # Line 85", "    #", "    # Line 87"], false),
         ]
     parsed_chunks = Literate.parse(content)
     compare_chunks(parsed_chunks, expected_chunks)
@@ -201,6 +211,8 @@ content = """
     Source code only          #src
     ## # Comment
     ## another comment
+    #~ yet another comment and ...
+    #~... an ugly comment
     #-
     for i in 1:10
         print(i)
@@ -315,6 +327,8 @@ const GITLAB_ENV = Dict(
             x + 3
             # # Comment
             # another comment
+            # yet another comment and ...
+            #... an ugly comment
 
             for i in 1:10
                 print(i)
@@ -547,6 +561,8 @@ end end
             x * 3
             # # Comment
             # another comment
+            # yet another comment and ...
+            #... an ugly comment
             ````
 
             ````@example inputfile; continued = true
@@ -899,7 +915,9 @@ end end
                 "x * 3\\n",
                 "x * 3\\n",
                 "# # Comment\\n",
-                "# another comment"
+                "# another comment\\n",
+                "# yet another comment and ...\\n",
+                "#... an ugly comment"
                ],
             """,
 


### PR DESCRIPTION
Hi, 
as always, thanks for the great work!

This is just a proposal for an alternative syntax for julia comments in code blocks.
The usual style is `## comment` and this will render as `# comment`.

However, `##` is one of the code cell delimiters in VSCode (which are not user configurable).
Thus, the usual syntax can hinder a code cell oriented workflow.

I implemented `#~`, added docs and some tests.
* Of course, `~` is up for debate, but it seems to be present on most keyboard layouts and does not clash with comments in code blocks using other languages.
* By the replacement rules I placed in "src/Literate.jl", comments like `#~Comment` are allowed and render as `#Comment`.  
   The usual `## ` requires a blank space. What is the rationale behind this?