### PR TITLE
Hide code lines with `#hide` when executing Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Lines with trailing `#hide` are not shown in output of Markdown execution with Documenter
+  flavour. ([#188][github-188])
 
 ## [2.12.1] - 2022-02-10
 ### Fixed

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -522,7 +522,6 @@ function markdown(inputfile, outputdir=pwd(); config::AbstractDict=Dict(), kwarg
         else # isa(chunk, CodeChunk)
             iocode = IOBuffer()
             codefence = config["codefence"]::Pair
-            execute = config["execute"]::Bool
             write(iocode, codefence.first)
             # make sure the code block is finalized if we are printing to ```@example
             # (or ````@example, any number of backticks >= 3 works)
@@ -530,18 +529,18 @@ function markdown(inputfile, outputdir=pwd(); config::AbstractDict=Dict(), kwarg
                 write(iocode, "; continued = true")
             end
             write(iocode, '\n')
+            # filter out trailing #hide unless code is executed by Documenter
+            execute = config["execute"]::Bool
+            write_hide = isdocumenter(config) && !execute
+            write_line(line) = write_hide || !endswith(line, "#hide")
             for line in chunk.lines
-                # filter out trailing #hide (unless leaving it for Documenter)
-                if !endswith(line, "#hide") || (isdocumenter(config) && !execute)
-                    write(iocode, line, '\n')
-                end
+                write_line(line) && write(iocode, line, '\n')
             end
-            if isdocumenter(config) && !execute && REPL.ends_with_semicolon(chunk.lines[end])
+            if write_hide && REPL.ends_with_semicolon(chunk.lines[end])
                 write(iocode, "nothing #hide\n")
             end
             write(iocode, codefence.second, '\n')
-            write_code = !all(l -> endswith(l, "#hide"), chunk.lines) || (isdocumenter(config) && !execute)
-            write_code && write(iomd, seekstart(iocode))
+            any(write_line, chunk.lines) && write(iomd, seekstart(iocode))
             if execute
                 execute_markdown!(iomd, sb, join(chunk.lines, '\n'), outputdir;
                                   inputfile=config["literate_inputfile"],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -810,6 +810,11 @@ end end
                 #-
                 print("hello there")
                 nothing
+                #-
+                a = 2 + 2
+                print("a: ", a); nothing #hide
+                #-
+                47 #hide
                 """)
             Literate.markdown(inputfile, outdir; execute=true)
             markdown = read(joinpath(outdir, "inputfile.md"), String)
@@ -825,6 +830,12 @@ end end
             @test !occursin("246", markdown) # empty output because trailing ;
             @test !occursin("```\nnothing\n```", markdown) # empty output because nothing as return value
             @test occursin("```\nhello there\n```", markdown) # nothing as return value, non-empty stdout
+            @test occursin("```julia\na = 2 + 2\n```", markdown) # line with `#hide` removed
+            @test occursin("```\na: 4\n```", markdown) # nothing as return value, non-empty stdout
+            @test !occursin("```julia\n47 #hide\n```", markdown) # line with `#hide` removed
+            @test !occursin("```julia\n```", markdown) # no empty code block
+            @test occursin("```\n47\n```", markdown) # return value (even though line/block removed)
+
             # FranklinFlavor
             Literate.markdown(inputfile, outdir; execute=true, flavor=Literate.FranklinFlavor())
             markdown = read(joinpath(outdir, "inputfile.md"), String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -827,6 +827,7 @@ end end
             @test occursin("```@raw html\n<h1>MD</h1>\n```", markdown) # text/html
             @test occursin("```\nhello, world\n```", markdown) # stdout/stderr
             @test occursin("```\n42\n```", markdown) # result over stdout/stderr
+            @test occursin("```julia\n123+123;\n```", markdown) # no additional `nothing #hide`, fredrikekre/Literate.jl/issues/166#issuecomment-979987878
             @test !occursin("246", markdown) # empty output because trailing ;
             @test !occursin("```\nnothing\n```", markdown) # empty output because nothing as return value
             @test occursin("```\nhello there\n```", markdown) # nothing as return value, non-empty stdout


### PR DESCRIPTION
This PR fixes a surprising behaviour that seemed a bug to me, both intuitively and after reading the documentation. Feel free to close the PR if it is intended and there is another way to achieve the same behaviour :slightly_smiling_face: 

For different reasons, I would like to execute a Documenter-flavored Markdown file generated with Literate with Literate instead of Documenter. However, as with Documenter, I would like to suppress the output of lines that end with `#hide` in the final file. To my surprise, currently this does not work:
`````julia
julia> using Literate

julia> write("literate_script.jl",
       """
       a = 2 + 2
       print("a: ", a); nothing #hide
       """);

julia> Literate.markdown("literate_script.jl"; execute=true, credit=false);
[ Info: generating markdown page from ~/literate_script.jl
[ Info: writing result to ~/literate_script.md

julia> print(read("literate_script.md", String))
```@meta
EditURL = "<unknown>/literate_script.jl"
```

````julia
a = 2 + 2
print("a: ", a); nothing #hide
````

````
a: 4
````
`````
Including this file in a Documenter setup doesn't help either since Documenter does not remove lines in `julia` codeblocks (only in `@example` AFAIK).

With this PR the line is removed from the resulting Markdown file but, of course, still executed. Hence including it in my documentation yields the same output as if I would have executed the Markdown file with Documenter instead of Literate:
`````julia
julia> using Literate

julia> write("literate_script.jl",
       """
       a = 2 + 2
       print("a: ", a); nothing #hide
       """);

julia> Literate.markdown("literate_script.jl"; execute=true, credit=false);
[ Info: generating markdown page from ~/literate_script.jl
[ Info: writing result to ~/literate_script.md

julia> print(read("literate_script.md", String))
```@meta
EditURL = "<unknown>/literate_script.jl"
```

````julia
a = 2 + 2
````

````
a: 4
````
`````

@racinmat noticed this inconsistency in https://github.com/fredrikekre/Literate.jl/issues/166#issuecomment-979987878 as well. I checked that the example there is fixed as well, with this PR the code block is shown as
![image](https://user-images.githubusercontent.com/26102/153487397-301b156c-ab75-4336-82f0-2455acd51d89.png)