### PR TITLE
Change filename structure of generated image files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Image filenames resulting from executing markdown files
+  (`Literate.markdown(...; execute=true)`) have changed from a number based on
+  the hash of the source block to the format
+  `{name}-{blocknumber}.(svg|png|...)`. ([#204][github-204],
+  [#205][github-205])
 
 ## [2.13.4] - 2022-06-03
 ### Fixed
@@ -230,6 +236,8 @@ https://discourse.julialang.org/t/ann-literate-jl/10651 for release announcement
 [github-194]: https://github.com/fredrikekre/Literate.jl/pull/194
 [github-195]: https://github.com/fredrikekre/Literate.jl/pull/195
 [github-197]: https://github.com/fredrikekre/Literate.jl/issues/197
+[github-204]: https://github.com/fredrikekre/Literate.jl/issues/204
+[github-205]: https://github.com/fredrikekre/Literate.jl/pull/205
 
 [Unreleased]: https://github.com/fredrikekre/Literate.jl/compare/v2.13.4...HEAD
 [2.13.4]: https://github.com/fredrikekre/Literate.jl/compare/v2.13.3...v2.13.4

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -553,8 +553,7 @@ function markdown(inputfile, outputdir=pwd(); config::AbstractDict=Dict(), kwarg
     # create the markdown file
     sb = sandbox()
     iomd = IOBuffer()
-    continued = false
-    for chunk in chunks
+    for (chunknum, chunk) in enumerate(chunks)
         if isa(chunk, MDChunk)
             for line in chunk.lines
                 write(iomd, line.second, '\n') # skip indent here
@@ -587,7 +586,9 @@ function markdown(inputfile, outputdir=pwd(); config::AbstractDict=Dict(), kwarg
                                       inputfile=config["literate_inputfile"],
                                       fake_source=config["literate_outputfile"],
                                       flavor=config["flavor"],
-                                      image_formats=config["image_formats"])
+                                      image_formats=config["image_formats"],
+                                      file_prefix="$(config["name"])-$(chunknum)",
+                    )
                 end
             end
         end
@@ -604,7 +605,7 @@ end
 
 function execute_markdown!(io::IO, sb::Module, block::String, outputdir;
                            inputfile::String, fake_source::String,
-                           flavor::AbstractFlavor, image_formats::Vector)
+                           flavor::AbstractFlavor, image_formats::Vector, file_prefix::String)
     # TODO: Deal with explicit display(...) calls
     r, str, _ = execute_block(sb, block; inputfile=inputfile, fake_source=fake_source)
     # issue #101: consecutive codefenced blocks need newline
@@ -621,7 +622,7 @@ function execute_markdown!(io::IO, sb::Module, block::String, outputdir;
         end
         for (mime, ext) in image_formats
             if Base.invokelatest(showable, mime, r)
-                file = string(hash(block) % UInt32) * ext
+                file = file_prefix * ext
                 open(joinpath(outputdir, file), "w") do io
                     Base.invokelatest(show, io, mime, r)
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -291,6 +291,7 @@ const GITLAB_ENV = Dict(
     (k => nothing for k in keys(TRAVIS_ENV))...,
     (k => nothing for k in keys(ACTIONS_ENV))...,
 )
+
 @testset "Literate.script" begin; Base.CoreLogging.with_logger(Base.CoreLogging.NullLogger()) do
     mktempdir(@__DIR__) do sandbox
         cd(sandbox) do
@@ -833,9 +834,9 @@ end end
             markdown = read(joinpath(outdir, "inputfile.md"), String)
             @test occursin("```\n2\n```", markdown) # text/plain
             @test occursin("```\n2×2 $(Matrix{Int}):\n 1  2\n 3  4\n```", markdown) # text/plain
-            @test occursin(r"!\[\]\(\d+\.png\)", markdown) # image/png
-            @test occursin(r"!\[\]\(\d+\.jpeg\)", markdown) # image/jpeg
-            @test occursin(r"!\[\]\(\d+\.svg\)", markdown) # image/svg+xml, fredrikekre/Literate.jl#182
+            @test occursin(r"!\[\]\(inputfile-5\.png\)", markdown) # image/png
+            @test occursin(r"!\[\]\(inputfile-6\.jpeg\)", markdown) # image/jpeg
+            @test occursin(r"!\[\]\(inputfile-7\.svg\)", markdown) # image/svg+xml, fredrikekre/Literate.jl#182
             @test occursin("# MD", markdown) # text/markdown
             @test occursin("```@raw html\n<h1>MD</h1>\n```", markdown) # text/html
             @test occursin("```\nPlain\n```", markdown) # text/plain, fredrikekre/Literate#187


### PR DESCRIPTION
When executing markdown (Literate.markdown(...; execute=true) images where previously saved to files where the name was based on the hash of the source block. This patch changes this such that files instead follow the format {name}-{blocknumber}.(svg|png|...). Closes #204.