### PR TITLE
Correctly handle refs that span multiple lines

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -211,9 +211,9 @@ function replace_default(content, sym;
     # Run some Documenter specific things
     if !isdocumenter(config)
         ## - remove documenter style `@ref`s and `@id`s
-        push!(repls, r"\[(.*?)\]\(@ref\)" => s"\1")     # [foo](@ref) => foo
-        push!(repls, r"\[(.*?)\]\(@ref .*?\)" => s"\1") # [foo](@ref bar) => foo
-        push!(repls, r"\[(.*?)\]\(@id .*?\)" => s"\1")  # [foo](@id bar) => foo
+        push!(repls, r"\[([^]]+?)\]\(@ref\)"s => s"\1")     # [foo](@ref) => foo
+        push!(repls, r"\[([^]]+?)\]\(@ref .*?\)"s => s"\1") # [foo](@ref bar) => foo
+        push!(repls, r"\[([^]]+?)\]\(@id .*?\)"s => s"\1")  # [foo](@id bar) => foo
     end
 
     # do the replacements

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -262,6 +262,9 @@ content = """
     #nb # %% [markdown] {"meta": "data"}
     #nb # # Explicit markdown cell with metadata
 
+    # It can sometimes happen that a text editor line-wraps [a link which shouldn't
+    # break](@ref bbaarr)
+
     #=
     First multiline
     comment
@@ -441,6 +444,11 @@ const GITLAB_ENV = Dict(
             @test occursin("# \\int f(x) dx", script)
             @test occursin("# First multiline", script)
             @test occursin("# Second multiline comment", script)
+            @test occursin(
+                """
+                # It can sometimes happen that a text editor line-wraps a link which shouldn't
+                # break""",
+                script)
 
             # mdstrings
             mdstrings_file = "inputfile_mdstrings.jl"
@@ -631,6 +639,9 @@ end end
             hidden2 * hidden2
             ````
 
+            It can sometimes happen that a text editor line-wraps [a link which shouldn't
+            break](@ref bbaarr)
+            
             First multiline
             comment
 


### PR DESCRIPTION
Fixes https://github.com/fredrikekre/Literate.jl/issues/224.

The new regexes have the following behavior:

```julia
repls = []
push!(repls, r"\[([^]]+?)\]\(@ref\)"s => s"\1")     # [foo](@ref) => foo
push!(repls, r"\[([^]]+?)\]\(@ref .*?\)"s => s"\1") # [foo](@ref bar) => foo
push!(repls, r"\[([^]]+?)\]\(@id .*?\)"s => s"\1")  # [foo](@id bar) => foo

content = """
    # # [Example](@id example-id)
    # [foo](@ref), [bar](@ref bbaarr)
    x = 1
    """
for repl in repls
    content = replace(content, repl)
end
@assert content == """
    # # Example
    # foo, bar
    x = 1
    """

content = """
    # # [Example](@id example-id)
    #
    # [This is a long example which
    # wraps a line](@ref)
    #
    # [In this case the](@ref reference also
    # wraps a line)
    #    
    # x = 1
    """
for repl in repls
    content = replace(content, repl)
end
@assert content == """
    # # Example
    #
    # This is a long example which
    # wraps a line
    #
    # In this case the
    #    
    # x = 1
    """
```