### PR TITLE
Set source file for sandbox module

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -582,7 +582,7 @@ function markdown(inputfile, outputdir=pwd(); config::AbstractDict=Dict(), kwarg
         preprocessor(inputfile, outputdir; user_config=config, user_kwargs=kwargs, type=:md)
 
     # create the markdown file
-    sb = sandbox()
+    sb = sandbox(config["literate_outputfile"])
     iomd = IOBuffer()
     for (chunknum, chunk) in enumerate(chunks)
         if isa(chunk, MDChunk)
@@ -789,7 +789,7 @@ function jupyter_notebook(chunks, config)
 end
 
 function execute_notebook(nb; inputfile::String, fake_source::String, softscope::Bool)
-    sb = sandbox()
+    sb = sandbox(fake_source)
     execution_count = 0
     for cell in nb["cells"]
         cell["cell_type"] == "code" || continue
@@ -851,8 +851,14 @@ function sandbox()
     # eval(expr) is available in the REPL (i.e. Main) so we emulate that for the sandbox
     Core.eval(m, :(eval(x) = Core.eval($m, x)))
     # modules created with Module() does not have include defined
-    # abspath is needed since this will call `include_relative`
-    Core.eval(m, :(include(x) = Base.include($m, abspath(x))))
+    Core.eval(m, :(include(x) = Base.include($m, x)))
+    return m
+end
+
+function sandbox(source_file)
+    m = sandbox()
+    # For `include` to work, the source file must be set.
+    Core.eval(m, :(current_task().storage[:SOURCE_PATH] = $source_file))
     return m
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1310,6 +1310,15 @@ end end
             notebook = read(joinpath(outdir, "inputfile.ipynb"), String)
             @test occursin("\"data\": {\n      \"text/plain\": \"31\"\n     }", notebook)
 
+            # issue #251
+            write(inputfile, "include(joinpath(\"issue251\", \"A.jl\"))")
+            mkdir(joinpath(outdir, "issue251"))
+            write(joinpath(outdir, "issue251", "A.jl"), "include(\"B.jl\")")
+            write(joinpath(outdir, "issue251", "B.jl"), "230 + 21")
+            Literate.notebook(inputfile, outdir)
+            notebook = read(joinpath(outdir, "inputfile.ipynb"), String)
+            @test occursin("\"data\": {\n      \"text/plain\": \"251\"\n     }", notebook)
+
             # test error when executing notebook
             write(inputfile, "for i in 1:10\n    println(i)")
             r = @test_logs((:error, r"error when executing notebook based on input file: "), match_mode=:any,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1310,8 +1310,8 @@ end end
             notebook = read(joinpath(outdir, "inputfile.ipynb"), String)
             @test occursin("\"data\": {\n      \"text/plain\": \"31\"\n     }", notebook)
 
-            # issue #251
-            write(inputfile, "include(joinpath(\"issue251\", \"A.jl\"))")
+            # issue #251 (recursive include)
+            write(inputfile, "include(\"issue251/A.jl\")")
             mkdir(joinpath(outdir, "issue251"))
             write(joinpath(outdir, "issue251", "A.jl"), "include(\"B.jl\")")
             write(joinpath(outdir, "issue251", "B.jl"), "230 + 21")


### PR DESCRIPTION
This PR updates the definition of the sandbox module to get the correct behavior for `include`. 

As before, when `include` is used in an example, it searches relative to the output directory for the example file. The newly supported behavior is that when `include` is used in a file included from an example, that `include` will be relative to the calling file instead of the example file.

Fixes #251 