### PR TITLE
Write display() calls in markdown output

### DIFF
--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -702,7 +702,7 @@ end
 
 function display_markdown(io, data, outputdir, flavor, image_formats, file_prefix, plain_fence)
     if (flavor isa FranklinFlavor || flavor isa DocumenterFlavor) &&
-        Base.invokelatest(showable, MIME("text/html"), data)
+            Base.invokelatest(showable, MIME("text/html"), data)
         htmlfence = flavor isa FranklinFlavor ? ("~~~" => "~~~") : ("```@raw html" => "```")
         write(io, "\n", htmlfence.first, "\n")
         Base.invokelatest(show, io, MIME("text/html"), data)
@@ -734,7 +734,7 @@ end
 
 function display_markdown_mime(io, mime_dict, outputdir, flavor, image_formats, file_prefix, plain_fence)
     if (flavor isa FranklinFlavor || flavor isa DocumenterFlavor) &&
-        haskey(mime_dict, "text/html")
+            haskey(mime_dict, "text/html")
         htmlfence = flavor isa FranklinFlavor ? ("~~~" => "~~~") : ("```@raw html" => "```")
         data = mime_dict["text/html"]
         write(io, "\n", htmlfence.first, "\n")
@@ -775,6 +775,7 @@ function display_markdown_mime(io, mime_dict, outputdir, flavor, image_formats, 
     write(io, plain_fence.first)
     write(io, mime_dict["text/plain"])
     write(io, plain_fence.second, '\n')
+    return
 end
 
 

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -680,7 +680,7 @@ function execute_markdown!(
         continue_on_error::Bool
     )
     r, str, display_dicts = execute_block(
-        sb, block; inputfile=inputfile, fake_source = fake_source,
+        sb, block; inputfile = inputfile, fake_source = fake_source,
         softscope = softscope, continue_on_error = continue_on_error
     )
     # issue #101: consecutive codefenced blocks need newline

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -6,7 +6,7 @@ https://fredrikekre.github.io/Literate.jl/ for documentation.
 """
 module Literate
 
-import JSON, REPL, IOCapture
+import JSON, REPL, IOCapture, Base64
 
 include("IJulia.jl")
 import .IJulia
@@ -688,10 +688,8 @@ function execute_markdown!(
     plain_fence = "\n````\n" => "\n````"
 
     # Any explicit calls to display(...)
-    for dict in display_dicts
-        for (mime, data) in dict
-            display_markdown(io, data, outputdir, flavor, image_formats, file_prefix, plain_fence)
-        end
+    for (i, d) in enumerate(display_dicts)
+        display_markdown_mime(io, d, outputdir, flavor, image_formats, "$(file_prefix)-$i", plain_fence)
     end
 
     if r !== nothing && !REPL.ends_with_semicolon(block)
@@ -717,7 +715,7 @@ function display_markdown(io, data, outputdir, flavor, image_formats, file_prefi
             open(joinpath(outputdir, file), "w") do io
                 Base.invokelatest(show, io, mime, data)
             end
-            write(io, "![](", file, ")\n")
+            write(io, "\n![](", file, ")\n")
             return
         end
     end
@@ -733,6 +731,52 @@ function display_markdown(io, data, outputdir, flavor, image_formats, file_prefi
     write(io, plain_fence.second, '\n')
     return
 end
+
+function display_markdown_mime(io, mime_dict, outputdir, flavor, image_formats, file_prefix, plain_fence)
+    if (flavor isa FranklinFlavor || flavor isa DocumenterFlavor) &&
+        haskey(mime_dict, "text/html")
+        htmlfence = flavor isa FranklinFlavor ? ("~~~" => "~~~") : ("```@raw html" => "```")
+        data = mime_dict["text/html"]
+        write(io, "\n", htmlfence.first, "\n")
+        write(io, data)
+        write(io, "\n", htmlfence.second, "\n")
+        return
+    end
+
+    for (mime, ext) in image_formats
+        if haskey(mime_dict, string(mime))
+            data = mime_dict[string(mime)]
+            file = file_prefix * ext
+            if istextmime(mime)
+                write(joinpath(outputdir, file), data)
+            else
+                data_decoded = Base64.base64decode(data)
+                write(joinpath(outputdir, file), data_decoded)
+            end
+            write(io, "\n![](", file, ")\n")
+            return
+        end
+    end
+
+    if haskey(mime_dict, "text/latex")
+        data = mime_dict["text/latex"]
+        write(io, "\n```latex\n", data, "\n```\n")
+        return
+    end
+
+    if haskey(mime_dict, "text/markdown")
+        data = mime_dict["text/markdown"]
+        write(io, '\n', data, '\n')
+        return
+    end
+
+    # fallback to text/plain
+    @assert haskey(mime_dict, "text/plain")
+    write(io, plain_fence.first)
+    write(io, mime_dict["text/plain"])
+    write(io, plain_fence.second, '\n')
+end
+
 
 const JUPYTER_VERSION = v"4.3.0"
 

--- a/src/Literate.jl
+++ b/src/Literate.jl
@@ -679,50 +679,60 @@ function execute_markdown!(
         image_formats::Vector, file_prefix::String, softscope::Bool,
         continue_on_error::Bool
     )
-    # TODO: Deal with explicit display(...) calls
-    r, str, _ = execute_block(
-        sb, block; inputfile = inputfile, fake_source = fake_source,
+    r, str, display_dicts = execute_block(
+        sb, block; inputfile=inputfile, fake_source = fake_source,
         softscope = softscope, continue_on_error = continue_on_error
     )
     # issue #101: consecutive codefenced blocks need newline
     # issue #144: quadruple backticks allow for triple backticks in the output
     plain_fence = "\n````\n" => "\n````"
+
+    # Any explicit calls to display(...)
+    for dict in display_dicts
+        for (mime, data) in dict
+            display_markdown(io, data, outputdir, flavor, image_formats, file_prefix, plain_fence)
+        end
+    end
+
     if r !== nothing && !REPL.ends_with_semicolon(block)
-        if (flavor isa FranklinFlavor || flavor isa DocumenterFlavor) &&
-                Base.invokelatest(showable, MIME("text/html"), r)
-            htmlfence = flavor isa FranklinFlavor ? ("~~~" => "~~~") : ("```@raw html" => "```")
-            write(io, "\n", htmlfence.first, "\n")
-            Base.invokelatest(show, io, MIME("text/html"), r)
-            write(io, "\n", htmlfence.second, "\n")
-            return
-        end
-        for (mime, ext) in image_formats
-            if Base.invokelatest(showable, mime, r)
-                file = file_prefix * ext
-                open(joinpath(outputdir, file), "w") do io
-                    Base.invokelatest(show, io, mime, r)
-                end
-                write(io, "![](", file, ")\n")
-                return
-            end
-        end
-        if Base.invokelatest(showable, MIME("text/markdown"), r)
-            write(io, '\n')
-            Base.invokelatest(show, io, MIME("text/markdown"), r)
-            write(io, '\n')
-            return
-        end
-        # fallback to text/plain
-        write(io, plain_fence.first)
-        Base.invokelatest(show, io, "text/plain", r)
-        write(io, plain_fence.second, '\n')
-        return
+        display_markdown(io, r, outputdir, flavor, image_formats, file_prefix, plain_fence)
     elseif !isempty(str)
         write(io, plain_fence.first, str, plain_fence.second, '\n')
         return
     end
 end
 
+function display_markdown(io, data, outputdir, flavor, image_formats, file_prefix, plain_fence)
+    if (flavor isa FranklinFlavor || flavor isa DocumenterFlavor) &&
+        Base.invokelatest(showable, MIME("text/html"), data)
+        htmlfence = flavor isa FranklinFlavor ? ("~~~" => "~~~") : ("```@raw html" => "```")
+        write(io, "\n", htmlfence.first, "\n")
+        Base.invokelatest(show, io, MIME("text/html"), data)
+        write(io, "\n", htmlfence.second, "\n")
+        return
+    end
+    for (mime, ext) in image_formats
+        if Base.invokelatest(showable, mime, data)
+            file = file_prefix * ext
+            open(joinpath(outputdir, file), "w") do io
+                Base.invokelatest(show, io, mime, data)
+            end
+            write(io, "![](", file, ")\n")
+            return
+        end
+    end
+    if Base.invokelatest(showable, MIME("text/markdown"), data)
+        write(io, '\n')
+        Base.invokelatest(show, io, MIME("text/markdown"), data)
+        write(io, '\n')
+        return
+    end
+    # fallback to text/plain
+    write(io, plain_fence.first)
+    Base.invokelatest(show, io, "text/plain", data)
+    write(io, plain_fence.second, '\n')
+    return
+end
 
 const JUPYTER_VERSION = v"4.3.0"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1020,25 +1020,52 @@ end
 
         # Calls to display(x) and display(mime, x)
         script = """
-        struct DF x end
-        Base.show(io::IO, ::MIME"text/plain", df::DF) = print(io, "DF(\$(df.x)) as text/plain")
-        Base.show(io::IO, ::MIME"text/html", df::DF) = print(io, "DF(\$(df.x)) as text/html")
-        Base.show(io::IO, ::MIME"text/latex", df::DF) = print(io, "DF(\$(df.x)) as text/latex")
+        struct DF{N} x end
+        DF(x) = DF{x}(x)
+        Base.show(io::IO, ::MIME"text/plain", df::DF{1}) = print(io, "DF(\$(df.x)) as text/plain")
+        Base.show(io::IO, ::MIME"text/html", df::DF{2}) = print(io, "DF(\$(df.x)) as text/html")
+        Base.show(io::IO, ::MIME"text/markdown", df::DF{3}) = print(io, "DF(\$(df.x)) as text/markdown")
+        Base.show(io::IO, ::MIME"text/latex", df::DF{4}) = print(io, "DF(\$(df.x)) as text/latex")
+        Base.show(io::IO, ::MIME"image/svg+xml", df::DF{5}) = print(io, "DF(\$(df.x)) as image/svg+xml")
+        Base.show(io::IO, ::MIME"image/png", df::DF{6}) = print(io, "DF(\$(df.x)) as image/png")
         #-
-        foreach(display, [DF(1), DF(2)])
-        DF(3)
+        foreach(display, [DF(1), DF(2), DF(3), DF(4), DF(5)])
+        DF(6)
         #-
         display(MIME("text/latex"), DF(4))
         """
         write(inputfile, script)
         Literate.markdown(inputfile, outdir; execute=true)
         markdown = read(joinpath(outdir, "inputfile.md"), String)
-        @test occursin("````\n\"DF(1) as text/plain\"\n````", markdown)
-        @test occursin("````\n\"DF(1) as text/html\"\n````", markdown)
-        @test occursin("````\n\"DF(2) as text/plain\"\n````", markdown)
-        @test occursin("````\n\"DF(2) as text/html\"\n````", markdown)
-        @test occursin("```@raw html\nDF(3) as text/html\n```", markdown)
-        @test occursin("````\n\"DF(4) as text/latex\"\n````", markdown)
+
+        # Make sure each one shows up.
+        @test occursin("DF(1)", markdown)
+        @test occursin("DF(2)", markdown)
+        @test occursin("DF(3)", markdown)
+        @test occursin("DF(4)", markdown)
+        @test occursin("inputfile-3-5.svg", markdown)
+        @test occursin("inputfile-3.png", markdown)
+
+        # Check the ordering.
+        @test findfirst("DF(1)", markdown)[1] < findfirst("DF(2)", markdown)[1]
+        @test findfirst("DF(2)", markdown)[1] < findfirst("DF(3)", markdown)[1]
+        @test findfirst("DF(3)", markdown)[1] < findfirst("DF(4)", markdown)[1]
+        @test findfirst("DF(4)", markdown)[1] < findfirst("inputfile-3-5.svg", markdown)[1]
+        @test findfirst("inputfile-3-5.svg", markdown)[1] < findfirst("inputfile-3.png", markdown)[1]
+
+        # Check the formatting.
+        @test occursin("````\nDF(1) as text/plain\n````", markdown)
+        @test occursin("```@raw html\nDF(2) as text/html\n```", markdown)
+        @test occursin("\nDF(3) as text/markdown\n", markdown)
+        @test occursin("```latex\nDF(4) as text/latex\n```", markdown)
+        @test occursin("\n![](inputfile-3-5.svg)\n", markdown)
+        @test occursin("\n![](inputfile-3.png)\n", markdown)
+
+        svg = read(joinpath(outdir, "inputfile-3-5.svg"), String)
+        @test svg == "DF(5) as image/svg+xml"
+
+        png = read(joinpath(outdir, "inputfile-3.png"), String)
+        @test png == "DF(6) as image/png"
 
         # Softscope
         write(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1127,13 +1127,13 @@ end
                    "source": [
                     "Not markdown\\n",
                     "Not markdown"
-                   ],
+                   ]
                 """,
                 """
                    "source": [
                     "x * 1\\n",
                     "x * 1"
-                   ],
+                   ]
                 """,
                 """
                    "source": [
@@ -1151,7 +1151,7 @@ end
                    "source": [
                     "Not script\\n",
                     "Not script"
-                   ],
+                   ]
                 """,
                 """
                    "source": [
@@ -1159,7 +1159,7 @@ end
                     "x * 3\\n",
                     "# # Comment\\n",
                     "# another comment"
-                   ],
+                   ]
                 """,
                 """
                    "source": [

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1018,6 +1018,28 @@ end
         )
         @test read(joinpath(outdir, "inputfile-1.svg"), String) == "issue228"
 
+        # Calls to display(x) and display(mime, x)
+        script = """
+        struct DF x end
+        Base.show(io::IO, ::MIME"text/plain", df::DF) = print(io, "DF(\$(df.x)) as text/plain")
+        Base.show(io::IO, ::MIME"text/html", df::DF) = print(io, "DF(\$(df.x)) as text/html")
+        Base.show(io::IO, ::MIME"text/latex", df::DF) = print(io, "DF(\$(df.x)) as text/latex")
+        #-
+        foreach(display, [DF(1), DF(2)])
+        DF(3)
+        #-
+        display(MIME("text/latex"), DF(4))
+        """
+        write(inputfile, script)
+        Literate.markdown(inputfile, outdir; execute=true)
+        markdown = read(joinpath(outdir, "inputfile.md"), String)
+        @test occursin("````\n\"DF(1) as text/plain\"\n````", markdown)
+        @test occursin("````\n\"DF(1) as text/html\"\n````", markdown)
+        @test occursin("````\n\"DF(2) as text/plain\"\n````", markdown)
+        @test occursin("````\n\"DF(2) as text/html\"\n````", markdown)
+        @test occursin("```@raw html\nDF(3) as text/html\n```", markdown)
+        @test occursin("````\n\"DF(4) as text/latex\"\n````", markdown)
+
         # Softscope
         write(
             inputfile,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1024,15 +1024,14 @@ end
         DF(x) = DF{x}(x)
         Base.show(io::IO, ::MIME"text/plain", df::DF{1}) = print(io, "DF(\$(df.x)) as text/plain")
         Base.show(io::IO, ::MIME"text/html", df::DF{2}) = print(io, "DF(\$(df.x)) as text/html")
-        Base.show(io::IO, ::MIME"text/markdown", df::DF{3}) = print(io, "DF(\$(df.x)) as text/markdown")
-        Base.show(io::IO, ::MIME"text/latex", df::DF{4}) = print(io, "DF(\$(df.x)) as text/latex")
-        Base.show(io::IO, ::MIME"image/svg+xml", df::DF{5}) = print(io, "DF(\$(df.x)) as image/svg+xml")
-        Base.show(io::IO, ::MIME"image/png", df::DF{6}) = print(io, "DF(\$(df.x)) as image/png")
+        Base.show(io::IO, ::MIME"image/png", df::DF{3}) = print(io, "DF(\$(df.x)) as image/png")
+        Base.show(io::IO, ::MIME"text/markdown", df::DF{4}) = print(io, "DF(\$(df.x)) as text/markdown")
+        Base.show(io::IO, ::MIME"text/latex", df::DF{5}) = print(io, "DF(\$(df.x)) as text/latex")
+        Base.show(io::IO, ::MIME"image/svg+xml", df::DF{6}) = print(io, "DF(\$(df.x)) as image/svg+xml")
+        Base.show(io::IO, ::MIME"image/png", df::DF{7}) = print(io, "DF(\$(df.x)) as image/png")
         #-
-        foreach(display, [DF(1), DF(2), DF(3), DF(4), DF(5)])
-        DF(6)
-        #-
-        display(MIME("text/latex"), DF(4))
+        foreach(display, DF(i) for i in 1:6)
+        DF(7)
         """
         write(inputfile, script)
         Literate.markdown(inputfile, outdir; execute=true)
@@ -1041,31 +1040,37 @@ end
         # Make sure each one shows up.
         @test occursin("DF(1)", markdown)
         @test occursin("DF(2)", markdown)
-        @test occursin("DF(3)", markdown)
+        @test occursin("inputfile-3-3.png", markdown)
         @test occursin("DF(4)", markdown)
-        @test occursin("inputfile-3-5.svg", markdown)
+        @test occursin("DF(5)", markdown)
+        @test occursin("inputfile-3-6.svg", markdown)
         @test occursin("inputfile-3.png", markdown)
 
         # Check the ordering.
         @test findfirst("DF(1)", markdown)[1] < findfirst("DF(2)", markdown)[1]
-        @test findfirst("DF(2)", markdown)[1] < findfirst("DF(3)", markdown)[1]
-        @test findfirst("DF(3)", markdown)[1] < findfirst("DF(4)", markdown)[1]
-        @test findfirst("DF(4)", markdown)[1] < findfirst("inputfile-3-5.svg", markdown)[1]
-        @test findfirst("inputfile-3-5.svg", markdown)[1] < findfirst("inputfile-3.png", markdown)[1]
+        @test findfirst("DF(2)", markdown)[1] < findfirst("inputfile-3-3.png", markdown)[1]
+        @test findfirst("inputfile-3-3.png", markdown)[1] < findfirst("DF(4)", markdown)[1]
+        @test findfirst("DF(4)", markdown)[1] < findfirst("DF(5)", markdown)[1]
+        @test findfirst("DF(5)", markdown)[1] < findfirst("inputfile-3-6.svg", markdown)[1]
+        @test findfirst("inputfile-3-6.svg", markdown)[1] < findfirst("inputfile-3.png", markdown)[1]
 
         # Check the formatting.
         @test occursin("````\nDF(1) as text/plain\n````", markdown)
         @test occursin("```@raw html\nDF(2) as text/html\n```", markdown)
-        @test occursin("\nDF(3) as text/markdown\n", markdown)
-        @test occursin("```latex\nDF(4) as text/latex\n```", markdown)
-        @test occursin("\n![](inputfile-3-5.svg)\n", markdown)
+        @test occursin("\n![](inputfile-3-3.png)\n", markdown)
+        @test occursin("\nDF(4) as text/markdown\n", markdown)
+        @test occursin("```latex\nDF(5) as text/latex\n```", markdown)
+        @test occursin("\n![](inputfile-3-6.svg)\n", markdown)
         @test occursin("\n![](inputfile-3.png)\n", markdown)
 
-        svg = read(joinpath(outdir, "inputfile-3-5.svg"), String)
-        @test svg == "DF(5) as image/svg+xml"
+        image = read(joinpath(outdir, "inputfile-3-3.png"), String)
+        @test image == "DF(3) as image/png"
 
-        png = read(joinpath(outdir, "inputfile-3.png"), String)
-        @test png == "DF(6) as image/png"
+        image = read(joinpath(outdir, "inputfile-3-6.svg"), String)
+        @test image == "DF(6) as image/svg+xml"
+
+        image = read(joinpath(outdir, "inputfile-3.png"), String)
+        @test image == "DF(7) as image/png"
 
         # Softscope
         write(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1034,7 +1034,7 @@ end
         DF(7)
         """
         write(inputfile, script)
-        Literate.markdown(inputfile, outdir; execute=true)
+        Literate.markdown(inputfile, outdir; execute = true)
         markdown = read(joinpath(outdir, "inputfile.md"), String)
 
         # Make sure each one shows up.


### PR DESCRIPTION
@fredrikekre I made some changes to get the `display()` calls rendered for the markdown output, but I don't understand the multiple MIMEs for the same `display()` call. And I don't understand the use for the `split_mime()` call.

So this is an initial fix, but it seems to duplicate output to both plain text and HTML. Can you advise on the correct behavior?

Fixes #255