### PR TITLE
Support for Quarto Callout Blocks

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1531,6 +1531,20 @@ end
         > on multiple lines.
         """
         @test occursin(expected, output)
+        # Literate.markdown Literate.QuartoFlavor()
+        Literate.markdown(inputfile, sandbox; flavor = Literate.QuartoFlavor())
+        output = read(joinpath(sandbox, "input.qmd"), String)
+        expected = """
+        ::: {.callout-note}
+        This is a note on one line.
+        :::
+
+        ::: {.callout-warn title="Warning title text"}
+        This is a warning
+        on multiple lines.
+        :::
+        """
+        @test occursin(expected, output)
         # Literate.notebook
         Literate.notebook(inputfile, sandbox)
         output = read(joinpath(sandbox, "input.ipynb"), String)


### PR DESCRIPTION
Following #267 I implemented (basically copying your code) support for callout quarto blocks.
I added a test (hope it works, as I add plenty of weird message trying to run it).

I tried to add in the regex a function for detecting if there is a `collapse="true"` but could not get it work (I am not good at regex).
